### PR TITLE
Fixed no data error for challenge Index Action. Not a great fix needs…

### DIFF
--- a/ladders/Controllers/ChallengesController.cs
+++ b/ladders/Controllers/ChallengesController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ladders.Models;
@@ -32,10 +33,16 @@ namespace ladders.Controllers
             var me = await Helpers.GetMe(User, _context);
             ViewBag.Me = me;
             ViewBag.IsAdmin = Helpers.AmIAdmin(User);
-            ViewBag.Challenged = _context.Challenge.Where(c => c.Challengee == me);
-            ViewBag.Challenging = _context.Challenge.Where(c => c.Challenger == me);
-
-            return View(await _context.Challenge.Where(c => c.Challenger == me || c.Challengee == me).ToListAsync());
+            
+            if (me != null)
+            {
+                ViewBag.Challenged = _context.Challenge.Where(c => c.Challengee == me); //TODO Also prop shouldn't have IQueriable used in View
+                ViewBag.Challenging = _context.Challenge.Where(c => c.Challenger == me);
+                return View(await _context.Challenge.Where(c => c.Challenger == me || c.Challengee == me).ToListAsync());
+            }
+            ViewBag.Challenged = _context.Challenge.Where(c => c.Challengee == new ProfileModel()); //TODO dirty fix (for now) for no challenges in DB
+            ViewBag.Challenging = _context.Challenge.Where(c => c.Challenger == new ProfileModel());
+            return View(new List<Challenge>());
         }
 
         // GET: Challenges/Details/5


### PR DESCRIPTION
… revisiting.

Probably a better fix would be to start using Repository classes to take IQueriable objects out of the views and also the out of the controllers. But for now we shouldn't get the error when the challenges db table is empty.